### PR TITLE
Remove async requirement from Watch channel send methods

### DIFF
--- a/kioto/channels/api.py
+++ b/kioto/channels/api.py
@@ -15,23 +15,10 @@ def channel_unbounded() -> tuple[impl.Sender, impl.Receiver]:
     return sender, receiver
 
 def oneshot_channel():
-    channel = asyncio.Future()
-
-    class OneShotSender:
-        def __init__(self):
-            self._sent = False
-
-        def send(self, value):
-            if self._sent:
-                raise RuntimeError("Value has already been sent on channel")
-
-            channel.set_result(value)
-            self._sent = True
-
-    async def receiver():
-        return await channel
-
-    return OneShotSender(), receiver()
+    channel = impl.OneShotChannel()
+    sender = impl.OneShotSender(channel)
+    receiver = impl.OneShotReceiver(channel)
+    return sender, receiver()
 
 def watch(initial_value: Any) -> tuple[impl.WatchSender, impl.WatchReceiver]:
     channel = impl.WatchChannel(initial_value)

--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -259,16 +259,16 @@ class WatchChannel:
 
     async def wait(self):
         # Create a oneshot channel
-        channel = impl.OneShotChannel()
-        sender = impl.OneShotSender(channel)
-        receiver = impl.OneShotReceiver(channel)
+        channel = OneShotChannel()
+        sender = OneShotSender(channel)
+        receiver = OneShotReceiver(channel)
 
         # Register the sender
         self._waiters.append(sender)
 
         # wait for notification
         try:
-            await receiver
+            await receiver()
         finally:
             self._waiters.remove(sender)
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -304,6 +304,7 @@ async def test_watch_channel_borrow_and_update():
 @pytest.mark.asyncio
 async def test_watch_channel_changed():
     tx, rx = watch(1)
+    assert 1 == rx.borrow_and_update()
 
     tx.send(2)
     await rx.changed()
@@ -312,6 +313,27 @@ async def test_watch_channel_changed():
     tx.send(3)
     await rx.changed()
     assert 3 == rx.borrow_and_update()
+
+@pytest.mark.asyncio
+async def test_watch_channel_multi_consumer():
+    tx, rx1 = watch(1)
+    rx2 = tx.subscribe()
+
+    a = rx1.borrow_and_update()
+    b = rx2.borrow_and_update()
+
+    assert 1 == a == b
+
+    tx.send(2)
+    a = rx1.borrow_and_update()
+    assert 2 == a
+
+    tx.send(3)
+    a = rx1.borrow_and_update()
+    b = rx2.borrow_and_update()
+
+    assert 3 == a == b
+
 
 @pytest.mark.asyncio
 async def test_watch_channel_receiver_stream():


### PR DESCRIPTION
Watch channel now uses a sync mutex and oneshot channel notification system to prevent async requirement on send methods.