### PR TITLE
Channel notification

### DIFF
--- a/kioto/channels/__init__.py
+++ b/kioto/channels/__init__.py
@@ -1,1 +1,2 @@
 from kioto.channels.api import channel, channel_unbounded, oneshot_channel, watch
+from kioto.channels.error import ChannelFull, ChannelEmpty, SendersDisconnected, ReceiversDisconnected, SenderSinkClosed, ReceiverExhausted

--- a/kioto/channels/api.py
+++ b/kioto/channels/api.py
@@ -9,7 +9,7 @@ def channel(capacity: int) -> tuple[impl.Sender, impl.Receiver]:
     return sender, receiver
 
 def channel_unbounded() -> tuple[impl.Sender, impl.Receiver]:
-    channel = impl.Channel(0)
+    channel = impl.Channel(None)
     sender = impl.Sender(channel)
     receiver = impl.Receiver(channel)
     return sender, receiver

--- a/kioto/channels/error.py
+++ b/kioto/channels/error.py
@@ -1,0 +1,20 @@
+class ChannelFull(Exception):
+    pass
+
+class ChannelEmpty(Exception):
+    pass
+
+class SendersDisconnected(Exception):
+    pass
+
+class ReceiversDisconnected(Exception):
+    pass
+
+class SenderSinkClosed(Exception):
+    pass
+
+class SenderExhausted(Exception):
+    pass
+
+class ReceiverExhausted(Exception):
+    pass

--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -48,7 +48,7 @@ class Channel:
 
     def size(self):
         return len(self.sync_queue)
-    
+
     def empty(self):
         return self.size() == 0
 
@@ -125,7 +125,7 @@ class Sender:
                 return
 
             # TODO: wait for receiver notification
-            await self._wait_for_capacity()
+            await self._channel.wait_for_receiver()
 
     def send(self, item: Any):
         """
@@ -185,7 +185,7 @@ class Receiver:
         while True:
             if not self._channel.empty():
                 item = self._channel.sync_queue.popleft()
-                self._channel.notify_receiver()
+                self._channel.notify_sender()
                 return item
 
             if not self._channel.has_senders():
@@ -400,7 +400,7 @@ class WatchSender:
             ReceiversDisconnected: if no receivers exist
         """
         if not self._channel.has_receivers():
-            raise error.ReceiversDisconnected 
+            raise error.ReceiversDisconnected
 
         current = self._channel.get_current_value()
         new_value = func(current)
@@ -417,7 +417,7 @@ class WatchSender:
             ReceiversDisconnected: if no receivers exist
         """
         if not self._channel.has_receivers():
-            raise error.ReceiversDisconnected 
+            raise error.ReceiversDisconnected
 
         current = self._channel.get_current_value()
         new_value = func(current)

--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -227,17 +227,14 @@ class SenderSink(Sink):
         if self._closed:
             raise error.SenderSinkClosed
         await self._sender.send_async(item)
-        await self.flush()
 
     async def flush(self):
         if self._closed:
             raise error.SenderSinkClosed
-        #await self._channel.join()
 
     async def close(self):
         if not self._closed:
             del self._sender
-            await self.flush()
             self._closed = True
 
 

--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -248,7 +248,7 @@ class ReceiverStream(Stream):
     async def __anext__(self):
         try:
             return await self._receiver.recv()
-        except Exception:
+        except error.SendersDisconnected:
             raise StopAsyncIteration
 
 class OneShotChannel(asyncio.Future):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ strict = true
 testpaths = ["tests"]
 pythonpath = "."
 
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
+
 # Enable coverage reporting within pytest
 addopts = "--cov=kioto --cov-report=term-missing --cov-report=html"
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -66,6 +66,19 @@ async def test_channel_drop_sender():
         await rx.recv()
 
 @pytest.mark.asyncio
+async def test_channel_drop_sender_parked_receiver():
+    tx, rx = channel(1)
+
+    rx_task = asyncio.create_task(rx.recv())
+
+    await asyncio.sleep(0.1)
+    del tx
+
+    with pytest.raises(RuntimeError):
+        await rx_task
+
+
+@pytest.mark.asyncio
 async def test_channel_drop_recv():
     tx, rx = channel(1)
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -86,6 +86,33 @@ async def test_channel_send_then_drop_sender_parked_receiver():
     assert 1 == await rx_task
 
 @pytest.mark.asyncio
+async def test_channel_send_park_on_full_recv_unpark():
+    tx, rx = channel(1)
+
+    async def park_sender():
+        await tx.send_async(1)
+        await tx.send_async(2)
+
+    send_task = asyncio.create_task(park_sender())
+    assert 1 == await rx.recv()
+    assert 2 == await rx.recv()
+    await send_task
+
+@pytest.mark.asyncio
+async def test_channel_recv_park_on_empty_send_unpark():
+    tx, rx = channel(1)
+
+    async def park_receiver():
+        assert 1 == await rx.recv()
+        assert 2 == await rx.recv()
+
+    recv_task = asyncio.create_task(park_receiver())
+    await tx.send_async(1)
+    await tx.send_async(2)
+    await recv_task
+
+
+@pytest.mark.asyncio
 async def test_channel_drop_recv():
     tx, rx = channel(1)
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 
 from kioto import streams, futures
-from kioto.channels import channel, channel_unbounded, oneshot_channel, watch
+from kioto.channels import error, channel, channel_unbounded, oneshot_channel, watch
 
 @pytest.mark.asyncio
 async def test_channel_send_recv_unbounded():
@@ -23,7 +23,7 @@ async def test_channel_bounded_send_recv():
     tx.send(2)
     tx.send(3)
 
-    with pytest.raises(asyncio.QueueFull):
+    with pytest.raises(error.ChannelFull):
         tx.send(4)
 
     x = await rx.recv()
@@ -62,7 +62,7 @@ async def test_channel_drop_sender():
     assert 1 == result
 
     # Sender was dropped no more data will ever be received
-    with pytest.raises(RuntimeError):
+    with pytest.raises(error.SendersDisconnected):
         await rx.recv()
 
 @pytest.mark.asyncio
@@ -70,13 +70,20 @@ async def test_channel_drop_sender_parked_receiver():
     tx, rx = channel(1)
 
     rx_task = asyncio.create_task(rx.recv())
-
-    await asyncio.sleep(0.1)
     del tx
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(error.SendersDisconnected):
         await rx_task
 
+@pytest.mark.asyncio
+async def test_channel_send_then_drop_sender_parked_receiver():
+    tx, rx = channel(1)
+
+    rx_task = asyncio.create_task(rx.recv())
+    tx.send(1)
+    del tx
+
+    assert 1 == await rx_task
 
 @pytest.mark.asyncio
 async def test_channel_drop_recv():
@@ -85,7 +92,7 @@ async def test_channel_drop_recv():
     del rx
 
     # No receivers exist to receive the sent data
-    with pytest.raises(RuntimeError):
+    with pytest.raises(error.ReceiversDisconnected):
         tx.send(1)
 
 @pytest.mark.asyncio
@@ -93,7 +100,7 @@ async def test_channel_send_on_closed():
     tx, rx = channel(1)
 
     del rx
-    with pytest.raises(RuntimeError):
+    with pytest.raises(error.ReceiversDisconnected):
         tx.send(1)
 
 @pytest.mark.asyncio
@@ -101,7 +108,7 @@ async def test_channel_recv_on_closed():
     tx, rx = channel(1)
 
     del tx
-    with pytest.raises(RuntimeError):
+    with pytest.raises(error.SendersDisconnected):
         await rx.recv()
 
 
@@ -202,7 +209,7 @@ async def test_oneshot_channel_send_exhausted():
     result = await rx
 
     # You can only send on the channel once!
-    with pytest.raises(RuntimeError):
+    with pytest.raises(error.SenderExhausted):
         tx.send(2)
 
 @pytest.mark.asyncio
@@ -222,7 +229,7 @@ async def test_oneshot_channel_sender_dropped():
     tx, rx = oneshot_channel()
     del tx
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(error.SendersDisconnected):
         result = await rx
 
 
@@ -301,7 +308,7 @@ async def test_watch_channel_no_receivers():
     tx, rx = watch(1)
     del rx
 
-    with pytest.raises(RuntimeError, match="No receivers exist. Cannot send."):
+    with pytest.raises(error.ReceiversDisconnected):
         tx.send(2)
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes channel notifications, previously if a Receiver called send before the Sender was dropped without sending a message, then we would deadlock. This has been resolved by moving off of asyncio Queues and instead using our own oneshot channel for setting up notifications. Additionally I have added custom error types instead of runtime error for everything.