### PR TITLE
Add a then method on streams

### DIFF
--- a/kioto/streams/impl.py
+++ b/kioto/streams/impl.py
@@ -17,6 +17,9 @@ class Stream:
     def map(self, fn):
         return Map(self, fn)
 
+    def then(self, fn):
+        return Then(self, fn)
+
     def filter(self, predicate):
         return Filter(self, predicate)
 
@@ -74,6 +77,15 @@ class Map(Stream):
 
     async def __anext__(self):
         return self.fn(await anext(self.stream))
+
+class Then(Stream):
+    def __init__(self, stream, fn):
+        self.fn = fn
+        self.stream = stream
+
+    async def __anext__(self):
+        arg = await anext(self.stream)
+        return await self.fn(arg)
 
 
 class Filter(Stream):

--- a/kioto/streams/impl.py
+++ b/kioto/streams/impl.py
@@ -78,6 +78,7 @@ class Map(Stream):
     async def __anext__(self):
         return self.fn(await anext(self.stream))
 
+
 class Then(Stream):
     def __init__(self, stream, fn):
         self.fn = fn

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -30,6 +30,21 @@ async def test_map():
     result = await stream.collect()
     assert result == [4, 6, 8, 10]
 
+@pytest.mark.asyncio
+async def test_then():
+
+    async def task(arg):
+        return arg * 2
+
+    iterable = [1, 2, 3, 4, 5]
+    stream = streams.iter(iterable).then(task)
+
+    # Ensure anext works
+    assert await anext(stream) == 2
+
+    # Ensure iteration (within the collect) works
+    result = await stream.collect()
+    assert result == [4, 6, 8, 10]
 
 @pytest.mark.asyncio
 async def test_filter():

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -30,9 +30,9 @@ async def test_map():
     result = await stream.collect()
     assert result == [4, 6, 8, 10]
 
+
 @pytest.mark.asyncio
 async def test_then():
-
     async def task(arg):
         return arg * 2
 
@@ -45,6 +45,7 @@ async def test_then():
     # Ensure iteration (within the collect) works
     result = await stream.collect()
     assert result == [4, 6, 8, 10]
+
 
 @pytest.mark.asyncio
 async def test_filter():


### PR DESCRIPTION
Adds a `then` method analogous to `map` for streams, where the function argument is a coroutine.