### PR TITLE
Better buffering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kioto"
-version = "v0.1.5"
+version = "v0.1.6"
 description = "Async utilities library inspired by Tokio"
 readme = "README.md"
 authors = [{name="Brandon Ogle", email="oglebrandon@gmail.com"}]

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -88,7 +88,6 @@ async def test_buffered():
 
 @pytest.mark.asyncio
 async def test_buffered_early_yield():
-    
     @streams.async_stream
     async def slow_stream():
         yield 1
@@ -113,13 +112,14 @@ async def test_buffered_early_yield():
 
     # Check that we got concurrency
     assert duration < 0.15
-    
+
     # Check that buffered wasn't blocked on the 4th element
     assert duration < 1
 
     assert 4 == await anext(st)
     with pytest.raises(StopAsyncIteration):
         await anext(st)
+
 
 @pytest.mark.asyncio
 async def test_buffered_unordered():
@@ -149,9 +149,9 @@ async def test_buffered_unordered():
     duration = time.monotonic() - now
     assert duration < 1.2 * (n // c)
 
+
 @pytest.mark.asyncio
 async def test_buffered_unordered_early_yield():
-    
     @streams.async_stream
     async def slow_stream():
         yield 1
@@ -175,16 +175,17 @@ async def test_buffered_unordered_early_yield():
     duration = time.monotonic() - then
 
     assert {a, b, c} == {1, 2, 3}
-    
+
     # Check that we got concurrency
     assert duration < 0.15
-    
+
     # Check that buffered wasn't blocked on the 4th element
     assert duration < 1
 
     assert 4 == await anext(st)
     with pytest.raises(StopAsyncIteration):
         await anext(st)
+
 
 @pytest.mark.asyncio
 async def test_unordered_optimization():

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -87,6 +87,41 @@ async def test_buffered():
 
 
 @pytest.mark.asyncio
+async def test_buffered_early_yield():
+    
+    @streams.async_stream
+    async def slow_stream():
+        yield 1
+        yield 2
+        yield 3
+        await asyncio.sleep(1)
+        yield 4
+
+    async def f(x):
+        await asyncio.sleep(0.1)
+        return x
+
+    # Here we are requesting more buffered space than the actual stream contains.
+    # We want to assert that our stream yields elements before the sleep and before
+    # we hit the StopAsyncIteration
+    st = slow_stream().map(f).buffered(5)
+    then = time.monotonic()
+    assert 1 == await anext(st)
+    assert 2 == await anext(st)
+    assert 3 == await anext(st)
+    duration = time.monotonic() - then
+
+    # Check that we got concurrency
+    assert duration < 0.15
+    
+    # Check that buffered wasn't blocked on the 4th element
+    assert duration < 1
+
+    assert 4 == await anext(st)
+    with pytest.raises(StopAsyncIteration):
+        await anext(st)
+
+@pytest.mark.asyncio
 async def test_buffered_unordered():
     async def task(n):
         await asyncio.sleep(1)
@@ -114,6 +149,42 @@ async def test_buffered_unordered():
     duration = time.monotonic() - now
     assert duration < 1.2 * (n // c)
 
+@pytest.mark.asyncio
+async def test_buffered_unordered_early_yield():
+    
+    @streams.async_stream
+    async def slow_stream():
+        yield 1
+        yield 2
+        yield 3
+        await asyncio.sleep(1)
+        yield 4
+
+    async def f(x):
+        await asyncio.sleep(0.1)
+        return x
+
+    # Here we are requesting more buffered space than the actual stream contains.
+    # We want to assert that our stream yields elements before the sleep and before
+    # we hit the StopAsyncIteration
+    st = slow_stream().map(f).buffered_unordered(5)
+    then = time.monotonic()
+    a = await anext(st)
+    b = await anext(st)
+    c = await anext(st)
+    duration = time.monotonic() - then
+
+    assert {a, b, c} == {1, 2, 3}
+    
+    # Check that we got concurrency
+    assert duration < 0.15
+    
+    # Check that buffered wasn't blocked on the 4th element
+    assert duration < 1
+
+    assert 4 == await anext(st)
+    with pytest.raises(StopAsyncIteration):
+        await anext(st)
 
 @pytest.mark.asyncio
 async def test_unordered_optimization():

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ wheels = [
 
 [[package]]
 name = "kioto"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
The stream buffering methods had two bugs.
- if the input parameter was 1, then no buffering was occurring. This is because they would queue a single task and then immediately await it before yielding.
- if the input parameter was larger than the currently available number of elements in the stream, the stream would block until more data was available or the stream was exhausted.

The methods have been updated to create a spawning task and consuming tasks - the spawning task continuously consumes coroutines off the stream and spawns work if buffer space is available. The consuming task(s) yield completed work as soon as it becomes available.