### PR TITLE
Watch channel cancel fix

### DIFF
--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -331,9 +331,7 @@ class WatchChannel:
         """
         Notify all receivers that a new value is available
         """
-        while self._waiters:
-            tx = self._waiters.pop()
-            tx.send(())
+        notify_all(self._waiters)
 
     async def wait(self):
         # Create a oneshot channel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kioto"
-version = "v0.1.7"
+version = "v0.1.8"
 description = "Async utilities library inspired by Tokio"
 readme = "README.md"
 authors = [{name="Brandon Ogle", email="oglebrandon@gmail.com"}]

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -454,3 +454,19 @@ async def test_watch_channel_receiver_stream():
     del tx
     with pytest.raises(StopAsyncIteration):
         await anext(rx_stream)
+
+@pytest.mark.asyncio
+async def test_watch_channel_cancel():
+    tx, rx = watch(1)
+
+    task = asyncio.create_task(rx.changed())
+    await asyncio.sleep(.1)
+    task.cancel()
+
+    # Despite previous cancelation, we can still read the value
+    tx.send(1)
+    assert rx.borrow_and_update() == 1
+
+    tx.send(2)
+    assert rx.borrow_and_update() == 2
+

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -455,12 +455,13 @@ async def test_watch_channel_receiver_stream():
     with pytest.raises(StopAsyncIteration):
         await anext(rx_stream)
 
+
 @pytest.mark.asyncio
 async def test_watch_channel_cancel():
     tx, rx = watch(1)
 
     task = asyncio.create_task(rx.changed())
-    await asyncio.sleep(.1)
+    await asyncio.sleep(0.1)
     task.cancel()
 
     # Despite previous cancelation, we can still read the value
@@ -469,4 +470,3 @@ async def test_watch_channel_cancel():
 
     tx.send(2)
     assert rx.borrow_and_update() == 2
-

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ wheels = [
 
 [[package]]
 name = "kioto"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
The watch channel was using a separate notification method that was not checking the status of the underlying future (within the one shot channel). This meant that if the receiver side was canceled while waiting notification, future sends on the channel would raise a SendersExhausted exception.