### PR TITLE
Refactor select API

### DIFF
--- a/kioto/futures/impl.py
+++ b/kioto/futures/impl.py
@@ -5,25 +5,27 @@ from typing import Dict, Any, Optional
 class TaskSet:
     def __init__(self, tasks: Dict[str, Any]):
         """
-        Initialize the TaskGroup with a dictionary of named coroutines.
+        Initialize the TaskSet with a dictionary of named coroutines.
 
         :param tasks: A dictionary mapping task names to coroutine objects.
         """
         self._tasks = {
             name: asyncio.create_task(coro, name=name) for name, coro in tasks.items()
         }
+        # Tasks that have been cancelled but not yet awaited to completion.
+        self._cancelled_tasks: Dict[asyncio.Task, str] = {}
 
     def __bool__(self) -> bool:
         """
         Return True if there are any tasks in the group, False otherwise.
         """
-        return bool(self._tasks)
+        return bool(self._tasks) or bool(self._cancelled_tasks)
 
     def get_tasks(self):
         """
         Retrieve all active asyncio.Task instances in the group.
         """
-        return self._tasks.values()
+        return list(self._tasks.values()) + list(self._cancelled_tasks.keys())
 
     def pop_task(self, task: asyncio.Task) -> Optional[str]:
         """
@@ -57,17 +59,20 @@ class TaskSet:
         :param name: The name of the task to cancel.
         """
         task = self._tasks.pop(name, None)
-        if task and not task.done():
-            task.cancel()
+        if task:
+            if not task.done():
+                task.cancel()
+            self._cancelled_tasks[task] = name
 
     def cancel_all(self):
         """
         Cancel all active tasks in the group.
         """
-        for task in self._tasks.values():
+        for name, task in list(self._tasks.items()):
             if task and not task.done():
                 task.cancel()
-        self._tasks.clear()
+            self._cancelled_tasks[task] = name
+            del self._tasks[name]
 
 
 class Shared:

--- a/kioto/streams/api.py
+++ b/kioto/streams/api.py
@@ -62,11 +62,9 @@ def async_stream(f):
 async def select(**streams):
     group = impl.StreamSet(streams)
     while group.task_set():
-        try:
-            name, result = await futures.select(group.task_set())
-        except StopAsyncIteration:
+        name, result = await futures.select(group.task_set())
+        if isinstance(result, StopAsyncIteration):
             continue
-        else:
-            group.poll_again(name)
+        group.poll_again(name)
 
         yield name, result


### PR DESCRIPTION
## Summary
- improve TaskSet cancellation tracking
- return task results or errors from `select`
- update streams to match new select behaviour
- adjust tests for new API
- clean up TaskSet naming

## Testing
- `ruff check kioto/futures/impl.py kioto/futures/api.py kioto/streams/api.py kioto/streams/impl.py tests/test_futures.py`
- `pytest -q -p no:cov --override-ini addopts=''` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_68549de3cfb0832bbcaca6f1d31e2ed3