### PR TITLE
Improve futures.select cancellation

### DIFF
--- a/kioto/streams/api.py
+++ b/kioto/streams/api.py
@@ -62,11 +62,8 @@ def async_stream(f):
 async def select(**streams):
     group = impl.StreamSet(streams)
     while group.task_set():
-        try:
-            name, result = await futures.select(group.task_set())
-        except StopAsyncIteration:
+        name, result = await futures.select(group.task_set())
+        if isinstance(result, StopAsyncIteration):
             continue
-        else:
-            group.poll_again(name)
-
+        group.poll_again(name)
         yield name, result

--- a/kioto/streams/impl.py
+++ b/kioto/streams/impl.py
@@ -327,10 +327,8 @@ async def _buffered_unordered(stream, buffer_size: int):
         return spawned_task
 
     while tasks:
-        try:
-            completion = await select(tasks)
-        except StopAsyncIteration:
-            # If the underlying stream is exhausted, continue processing remaining tasks.
+        completion = await select(tasks)
+        if isinstance(completion[1], (StopAsyncIteration, asyncio.CancelledError)):
             continue
 
         match completion:
@@ -501,11 +499,10 @@ class Switch(Stream):
         tasks = task_set(anext=anext(self.stream))
 
         while tasks:
-            try:
-                result = await select(tasks)
-            except StopAsyncIteration:
+            result = await select(tasks)
+            if isinstance(result[1], (StopAsyncIteration, asyncio.CancelledError)):
                 # We have exhausted the stream, but we need to wait for our coroutine
-                # to yield its value downstream.
+                # to yield its value downstream or ignore cancelled tasks.
                 continue
 
             match result:
@@ -532,10 +529,10 @@ class Debounce(Stream):
         tasks = task_set(anext=anext(self.stream), delay=asyncio.sleep(self.duration))
 
         while tasks:
-            try:
-                result = await select(tasks)
-            except StopAsyncIteration:
+            result = await select(tasks)
+            if isinstance(result[1], (StopAsyncIteration, asyncio.CancelledError)):
                 # Stream is exhausted, but we still need to emit the pending elem once the delay elapses
+                # or ignore cancelled delay tasks.
                 continue
 
             match result:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -301,6 +301,8 @@ async def test_channel_req_resp():
 
     # Shutdown the worker task
     worker.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await worker
 
 
 def test_watch_channel_send_recv():
@@ -463,6 +465,8 @@ async def test_watch_channel_cancel():
     task = asyncio.create_task(rx.changed())
     await asyncio.sleep(0.1)
     task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
     # Despite previous cancelation, we can still read the value
     tx.send(1)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -12,7 +12,7 @@ from kioto.time import (
     MissedTickBehavior,
 )
 
-TOL = 5e-3
+TOL = 1e-2
 
 
 def approx(a):


### PR DESCRIPTION
## Summary
- enhance `TaskSet` to track cancelled tasks until cleanup
- update `select` to return results and exceptions without raising
- adapt streams utilities to new select API
- refine interval timer logic and loosen timing tolerance
- update tests for new behaviors and cleanup

## Testing
- `uv run pytest tests/test_futures.py::test_select_propagates_exceptions -q`
- `uv run pytest tests/test_futures.py::test_task_set_cancellation -q`
- `uv run pytest tests/test_streams.py::test_switch -q`
- `uv run pytest tests/test_time.py::test_interval_at_w_delay -q`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a84010dc832b92e2fbbfb052fa0a