### PR TITLE
Set oneshot channel from the event loop to ensure threadsafety

### DIFF
--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -272,7 +272,14 @@ class OneShotSender:
         if self._channel.done():
             raise error.SenderExhausted("Value has already been sent on channel")
 
-        self._channel.set_result(value)
+        loop = self._channel.get_loop()
+
+        def setter():
+            # NOTE: This code does not work if you dont schedule as a closure. WAT!
+            self._channel.set_result(value)
+        
+        # The result must be set from the thread that owns the underlying future
+        loop.call_soon_threadsafe(setter)
 
 
 class OneShotReceiver:

--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -277,7 +277,7 @@ class OneShotSender:
         def setter():
             # NOTE: This code does not work if you dont schedule as a closure. WAT!
             self._channel.set_result(value)
-        
+
         # The result must be set from the thread that owns the underlying future
         loop.call_soon_threadsafe(setter)
 


### PR DESCRIPTION
its not safe to call Future.set_result from a separate thread from the event loop. While I never observed this code failing, asyncio debug mode would flag this as a runtime error. The following code snippet could reproduce the failure - the same code succeeds with this PR.

```
import asyncio
import threading

from kioto.channels import watch

def sender(tx):
    for i in range(50000):
	    tx.send(i)

async def orchestrate():
    tx, rx = watch(None)
    t = threading.Thread(target=lambda: sender(tx))
    t.start()

    # Get the value 
    for i in range(5):
        await rx.changed()
        val = rx.borrow_and_update()
        print(val)

    # The thread should have exited
    t.join()
   
# Set debug to true - which will add run time thread safety checks around Futures
asyncio.run(orchestrate(), debug=True)
print("neat!")
```