### PR TITLE
 Add lock-free zero-copy SPSC buffer with async stream integration

### DIFF
--- a/kioto/channels/__init__.py
+++ b/kioto/channels/__init__.py
@@ -1,4 +1,4 @@
-from kioto.channels.api import channel, channel_unbounded, oneshot_channel, watch
+from kioto.channels.api import channel, channel_unbounded, oneshot_channel, watch, spsc_buffer
 from kioto.channels.error import (
     ChannelFull,
     ChannelEmpty,

--- a/kioto/channels/__init__.py
+++ b/kioto/channels/__init__.py
@@ -1,4 +1,10 @@
-from kioto.channels.api import channel, channel_unbounded, oneshot_channel, watch, spsc_buffer
+from kioto.channels.api import (
+    channel,
+    channel_unbounded,
+    oneshot_channel,
+    watch,
+    spsc_buffer,
+)
 from kioto.channels.error import (
     ChannelFull,
     ChannelEmpty,

--- a/kioto/channels/api.py
+++ b/kioto/channels/api.py
@@ -28,3 +28,19 @@ def watch(initial_value: Any) -> tuple[impl.WatchSender, impl.WatchReceiver]:
     sender = impl.WatchSender(channel)
     receiver = impl.WatchReceiver(channel)
     return sender, receiver
+
+
+def spsc_buffer(capacity: int) -> tuple[impl.SPSCSender, impl.SPSCReceiver]:
+    """
+    Create a Single Producer Single Consumer buffer for bytes.
+
+    Args:
+        capacity: Buffer capacity in bytes (will be rounded up to nearest power of 2)
+
+    Returns:
+        A tuple of (sender, receiver) for the SPSC buffer
+    """
+    buffer = impl.SPSCBuffer(capacity)
+    sender = impl.SPSCSender(buffer)
+    receiver = impl.SPSCReceiver(buffer)
+    return sender, receiver

--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -78,7 +78,7 @@ class BorrowedSlice:
         self._check_valid()
         return bytes(self._data).find(sub)
 
-    def decode(self, encoding='utf-8', errors='strict'):
+    def decode(self, encoding="utf-8", errors="strict"):
         self._check_valid()
         return bytes(self._data).decode(encoding, errors)
 
@@ -210,12 +210,12 @@ class SPSCBuffer:
 
         if tail_pos + to_write <= self._capacity:
             # No wrap around
-            self._buffer[tail_pos:tail_pos + to_write] = data[:to_write]
+            self._buffer[tail_pos : tail_pos + to_write] = data[:to_write]
         else:
             # Handle wrap around
             first_part = self._capacity - tail_pos
             self._buffer[tail_pos:] = data[:first_part]
-            self._buffer[:to_write - first_part] = data[first_part:to_write]
+            self._buffer[: to_write - first_part] = data[first_part:to_write]
 
         # Update tail atomically
         self._tail = (self._tail + to_write) & ((2 * self._capacity) - 1)
@@ -241,11 +241,11 @@ class SPSCBuffer:
 
         if head_pos + to_read <= self._capacity:
             # No wrap around
-            result = bytes(self._buffer[head_pos:head_pos + to_read])
+            result = bytes(self._buffer[head_pos : head_pos + to_read])
         else:
             # Handle wrap around
             first_part = self._capacity - head_pos
-            result = bytes(self._buffer[head_pos:] + self._buffer[:to_read - first_part])
+            result = bytes(self._buffer[head_pos:] + self._buffer[: to_read - first_part])
 
         # Update head atomically
         self._head = (self._head + to_read) & ((2 * self._capacity) - 1)
@@ -271,12 +271,12 @@ class SPSCBuffer:
 
         if head_pos + to_read <= self._capacity:
             # No wrap around
-            out[:to_read] = self._buffer[head_pos:head_pos + to_read]
+            out[:to_read] = self._buffer[head_pos : head_pos + to_read]
         else:
             # Handle wrap around
             first_part = self._capacity - head_pos
             out[:first_part] = self._buffer[head_pos:]
-            out[first_part:to_read] = self._buffer[:to_read - first_part]
+            out[first_part:to_read] = self._buffer[: to_read - first_part]
 
         # Update head atomically
         self._head = (self._head + to_read) & ((2 * self._capacity) - 1)
@@ -424,7 +424,9 @@ class SPSCReceiver:
                 raise error.SendersDisconnected
             await self._buffer._wait_for_writer()
 
-    def into_stream(self, buffer_size: int = 8192, min_size: int = 1) -> "SPSCReceiverStream":
+    def into_stream(
+        self, buffer_size: int = 8192, min_size: int = 1
+    ) -> "SPSCReceiverStream":
         """Convert this receiver into a stream."""
         return SPSCReceiverStream(self, buffer_size, min_size)
 
@@ -465,7 +467,9 @@ class SPSCReceiverStream(Stream):
     Provides zero-copy access through BorrowedSlice with explicit ownership semantics.
     """
 
-    def __init__(self, receiver: SPSCReceiver, buffer_size: int = 8192, min_size: int = 1):
+    def __init__(
+        self, receiver: SPSCReceiver, buffer_size: int = 8192, min_size: int = 1
+    ):
         self._receiver = receiver
         self._buffer_size = buffer_size
         self._min_size = min_size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kioto"
-version = "v0.1.10"
+version = "v0.1.11"
 description = "Async utilities library inspired by Tokio"
 readme = "README.md"
 authors = [{name="Brandon Ogle", email="oglebrandon@gmail.com"}]

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -2,7 +2,14 @@ import asyncio
 import pytest
 
 from kioto import streams, futures
-from kioto.channels import error, channel, channel_unbounded, oneshot_channel, watch, spsc_buffer
+from kioto.channels import (
+    error,
+    channel,
+    channel_unbounded,
+    oneshot_channel,
+    watch,
+    spsc_buffer,
+)
 from kioto.channels.impl import BorrowedSlice
 
 
@@ -475,6 +482,7 @@ async def test_watch_channel_cancel():
 
 # SPSC Buffer Tests
 
+
 def test_spsc_buffer_basic_send_recv():
     """Test basic synchronous send and receive operations."""
     tx, rx = spsc_buffer(1024)
@@ -660,6 +668,7 @@ def test_spsc_buffer_single_receiver_enforcement():
 async def test_spsc_buffer_sender_dropped():
     """Test behavior when sender is dropped."""
     import gc
+
     tx, rx = spsc_buffer(16)
 
     # Send some data
@@ -683,6 +692,7 @@ async def test_spsc_buffer_sender_dropped():
 async def test_spsc_buffer_receiver_dropped():
     """Test behavior when receiver is dropped."""
     import gc
+
     tx, rx = spsc_buffer(16)
 
     # Drop receiver
@@ -787,6 +797,7 @@ async def test_spsc_buffer_concurrent_operations():
 
 # BorrowedSlice and Zero-Copy Stream Tests
 
+
 @pytest.mark.asyncio
 async def test_spsc_buffer_receiver_stream_borrowed_slice():
     """Test receiver stream returns BorrowedSlice for zero-copy access."""
@@ -802,7 +813,7 @@ async def test_spsc_buffer_receiver_stream_borrowed_slice():
     assert len(borrowed) <= 8  # Should respect buffer size
 
     # Can read from borrowed slice without copying
-    assert borrowed[0] in [ord('h'), ord(' ')]  # Could be start of either word
+    assert borrowed[0] in [ord("h"), ord(" ")]  # Could be start of either word
     assert len(borrowed) >= 2  # Should respect min_size
 
 
@@ -893,8 +904,8 @@ def test_borrowed_slice_methods():
 
     # Test slice-like operations
     assert len(borrowed) == 11
-    assert borrowed[0] == ord('h')
-    assert borrowed[6] == ord('w')
+    assert borrowed[0] == ord("h")
+    assert borrowed[6] == ord("w")
 
     # Test slice methods
     assert borrowed.startswith(b"hello")
@@ -904,7 +915,7 @@ def test_borrowed_slice_methods():
 
     # Test iteration
     chars = list(borrowed)
-    assert chars[0] == ord('h')
+    assert chars[0] == ord("h")
 
     # Test equality
     assert borrowed == b"hello world"
@@ -922,7 +933,7 @@ def test_borrowed_slice_invalidation():
 
     # Should work initially
     assert len(borrowed) == 9
-    assert borrowed[0] == ord('t')
+    assert borrowed[0] == ord("t")
 
     # Invalidate
     borrowed.invalidate()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 
 [[package]]
@@ -104,7 +104,7 @@ wheels = [
 
 [[package]]
 name = "kioto"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR introduces a high-performance, lock-free Single Producer Single Consumer (SPSC) byte buffer optimized for streaming applications. Key features include:

- **Zero-Copy Semantics** via a new `BorrowedSlice` abstraction that supports read-only views with explicit invalidation and ownership through `.clone()`.
- **Async Integration** with `SPSCReceiverStream`, enabling `async for` consumption of streamed byte slices.
- **Memory-Safe Design** with runtime borrow checks to prevent use-after-invalidation errors.
- **Capacity Optimization** by rounding buffer size to the nearest power of two, enabling efficient bitmask arithmetic.
- **Single-Waiter Enforcement** for both producer and consumer sides to align with true SPSC semantics.
- **Sink Compatibility** by converting the sender into a `Sink` interface for structured data feeding.

Comprehensive tests cover buffer wraparound, partial reads/writes, concurrent async operations, proper cleanup on GC, and BorrowedSlice semantics. The implementation avoids memory leaks using weak references and ensures zero-allocation reads with explicit copy control for persistence.
