### PR TITLE
AsyncIterator bug fixes

### DIFF
--- a/kioto/channels/impl.py
+++ b/kioto/channels/impl.py
@@ -928,8 +928,5 @@ class WatchReceiverStream(Stream[T]):
     def __init__(self, receiver: WatchReceiver[T]):
         self._stream = _watch_stream(receiver)
 
-    async def __aiter__(self) -> AsyncIterator[T]:
-        return self._stream
-
     async def __anext__(self) -> T:
         return await anext(self._stream)


### PR DESCRIPTION
Refactor WatchReceiverStream/Debounce/Switch to use __anext__ and default __aiter__ impl.

This consistency ensures that kioto.streams can be used in `async for` syntax and be the argument to `anext`.